### PR TITLE
Use more informative project name

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -2,7 +2,7 @@
  * Gradle settings.
  */
 
-rootProject.name = 'demo-javafx-control'
+rootProject.name = 'qupath-log-viewer'
 
 dependencyResolutionManagement {
 


### PR DESCRIPTION
This repo started out from https://github.com/petebankhead/javafx-ui-template and I forgot to change the project name...

Note that the gradle project will probably need to be refreshed within any IDE after merging this.