### PR TITLE
Added reload4j as alternative logging framework

### DIFF
--- a/log-viewer-app/build.gradle
+++ b/log-viewer-app/build.gradle
@@ -21,8 +21,11 @@ dependencies {
     // Use logging abstraction. This also import SLF4J.
     implementation project(':log-viewer-api')
 
-    // Use implementation of Logback
-    implementation project(':log-viewer-logback')
+    // Use Logback implementation.
+    //implementation project(':log-viewer-logback')
+
+    // Use reload4j implementation.
+    implementation project(':log-viewer-reload4j')
 }
 
 java {

--- a/log-viewer-app/src/main/java/io/github/qupath/logviewer/app/LogViewerController.java
+++ b/log-viewer-app/src/main/java/io/github/qupath/logviewer/app/LogViewerController.java
@@ -96,7 +96,7 @@ public class LogViewerController implements LoggerController {
             setUpMinimumLogLevel(loggerManager);
 
             if (allProviders.hasNext()) {
-                logger.atWarn().setMessage("More than one logging manager detected. {} was selected.").addArgument(loggerManager).log();
+                logger.atWarn().setMessage("More than one logging manager detected. The log messages may not be correctly forwarded.").log();
             }
         } else {
             System.err.println("No logging manager found");
@@ -131,9 +131,11 @@ public class LogViewerController implements LoggerController {
 
         minimumLogLevelMenu.setOnShowing(event -> {
             Level currentLevel = manager.getRootLogLevel();
+            String currentLevelStr = currentLevel == null ? "" : currentLevel.toString();
+
             for (MenuItem item : minimumLogLevelMenu.getItems()) {
                 RadioMenuItem radioMenuItem = (RadioMenuItem) item;
-                radioMenuItem.setSelected(radioMenuItem.getText().equals(currentLevel.toString()));
+                radioMenuItem.setSelected(radioMenuItem.getText().equals(currentLevelStr));
             }
         });
     }

--- a/log-viewer-logback/src/main/java/io/github/qupath/logviewer/logback/LogbackManager.java
+++ b/log-viewer-logback/src/main/java/io/github/qupath/logviewer/logback/LogbackManager.java
@@ -38,11 +38,11 @@ public class LogbackManager implements LoggerManager {
 
     public static Level toSlf4JLevel(ch.qos.logback.classic.Level level) {
         return switch (level.toInt()) {
-            case ch.qos.logback.classic.Level.TRACE_INT -> Level.TRACE;
+            case ch.qos.logback.classic.Level.TRACE_INT, ch.qos.logback.classic.Level.ALL_INT -> Level.TRACE;
             case ch.qos.logback.classic.Level.DEBUG_INT -> Level.DEBUG;
             case ch.qos.logback.classic.Level.INFO_INT -> Level.INFO;
             case ch.qos.logback.classic.Level.WARN_INT -> Level.WARN;
-            case ch.qos.logback.classic.Level.ERROR_INT -> Level.ERROR;
+            case ch.qos.logback.classic.Level.ERROR_INT, ch.qos.logback.classic.Level.OFF_INT -> Level.ERROR;
             default -> null;
         };
     }

--- a/log-viewer-reload4j/build.gradle
+++ b/log-viewer-reload4j/build.gradle
@@ -1,0 +1,26 @@
+plugins {
+    // Apply the Java library plugin to add support for building a library in Java.
+    id 'java-library'
+}
+
+repositories {
+    // Use Maven Central for resolving dependencies.
+    mavenCentral()
+}
+
+dependencies {
+    // Use reload4j as logging framework.
+    implementation 'ch.qos.reload4j:reload4j:1.2.25'
+
+    // Use SLF4J Reload4j Binding.
+    implementation 'org.slf4j:slf4j-reload4j:2.0.7'
+
+    // Use logging abstraction.
+    implementation project(':log-viewer-api')
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}

--- a/log-viewer-reload4j/src/main/java/io/github/qupath/logviewer/reload4j/LogViewerAppender.java
+++ b/log-viewer-reload4j/src/main/java/io/github/qupath/logviewer/reload4j/LogViewerAppender.java
@@ -1,0 +1,38 @@
+package io.github.qupath.logviewer.reload4j;
+
+import io.github.qupath.logviewer.api.LogMessage;
+import io.github.qupath.logviewer.api.LoggerController;
+import org.apache.log4j.AppenderSkeleton;
+import org.apache.log4j.spi.LoggingEvent;
+
+public class LogViewerAppender extends AppenderSkeleton {
+    private final LoggerController controller;
+
+    public LogViewerAppender(LoggerController controller) {
+        this.controller = controller;
+    }
+
+    @Override
+    protected void append(LoggingEvent event) {
+        var message = new LogMessage(
+                event.getLoggerName(),
+                event.getTimeStamp(),
+                event.getThreadName(),
+                Reload4jManager.toSlf4JLevel(event.getLevel()),
+                event.getRenderedMessage(),
+                event.getThrowableInformation() == null ? null : event.getThrowableInformation().getThrowable()
+        );
+        controller.addLogMessage(message);
+    }
+
+    @Override
+    public void close() {
+
+    }
+
+    @Override
+    public boolean requiresLayout() {
+        return false;
+    }
+}
+

--- a/log-viewer-reload4j/src/main/java/io/github/qupath/logviewer/reload4j/Reload4jManager.java
+++ b/log-viewer-reload4j/src/main/java/io/github/qupath/logviewer/reload4j/Reload4jManager.java
@@ -1,0 +1,53 @@
+package io.github.qupath.logviewer.reload4j;
+
+import io.github.qupath.logviewer.api.LoggerController;
+import io.github.qupath.logviewer.api.LoggerManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
+
+public class Reload4jManager implements LoggerManager {
+    private final static Logger logger = LoggerFactory.getLogger(Reload4jManager.class);
+    private final static org.apache.log4j.Logger root = org.apache.log4j.Logger.getRootLogger();
+
+    @Override
+    public void addAppender(LoggerController controller) {
+        if (root != null) {
+            var appender = new LogViewerAppender(controller);
+            appender.setName("LogViewer");
+            root.addAppender(appender);
+        } else {
+            logger.warn("Cannot add appender to root logger using logback!");
+        }
+    }
+
+    @Override
+    public void setRootLogLevel(Level level) {
+        if (root != null) {
+            root.setLevel(switch (level) {
+                case WARN -> org.apache.log4j.Level.WARN;
+                case DEBUG -> org.apache.log4j.Level.DEBUG;
+                case TRACE -> org.apache.log4j.Level.TRACE;
+                case ERROR -> org.apache.log4j.Level.ERROR;
+                case INFO -> org.apache.log4j.Level.INFO;
+            });
+        }
+    }
+
+    @Override
+    public Level getRootLogLevel() {
+        return root == null ? null : toSlf4JLevel(root.getLevel());
+    }
+
+    public static Level toSlf4JLevel(org.apache.log4j.Level level) {
+        return switch (level.toInt()) {
+            case org.apache.log4j.Level.WARN_INT -> Level.WARN;
+            case org.apache.log4j.Level.DEBUG_INT -> Level.DEBUG;
+            case org.apache.log4j.Level.TRACE_INT, org.apache.log4j.Level.ALL_INT -> Level.TRACE;
+            case org.apache.log4j.Level.ERROR_INT, org.apache.log4j.Level.FATAL_INT, org.apache.log4j.Level.OFF_INT -> Level.ERROR;
+            case org.apache.log4j.Level.INFO_INT -> Level.INFO;
+            default -> null;
+        };
+    }
+}
+

--- a/log-viewer-reload4j/src/main/java/module-info.java
+++ b/log-viewer-reload4j/src/main/java/module-info.java
@@ -1,0 +1,12 @@
+import io.github.qupath.logviewer.reload4j.Reload4jManager;
+
+module logviewer.reload4j {
+    exports io.github.qupath.logviewer.reload4j;
+
+    requires org.slf4j;
+    requires logviewer.api;
+    requires ch.qos.reload4j;
+
+    provides io.github.qupath.logviewer.api.LoggerManager with Reload4jManager;
+
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -8,3 +8,4 @@ include 'log-viewer-api'
 
 // Logging modules
 include 'log-viewer-logback'
+include 'log-viewer-reload4j'


### PR DESCRIPTION
`Logback` or `reload4j` (one, not both) can be selected by commenting / uncommenting the corresponding dependencies in *log-viewer-app/build.gradle*.