### PR TITLE
Small styling changes

### DIFF
--- a/log-viewer/src/main/resources/qupath/ui/logviewer/css/styles.css
+++ b/log-viewer/src/main/resources/qupath/ui/logviewer/css/styles.css
@@ -43,3 +43,8 @@
 .error {
     -fx-text-fill: error;
 }
+
+/* Default log table styling */
+.log-table {
+    -fx-font-size: 90%;
+}

--- a/log-viewer/src/main/resources/qupath/ui/logviewer/log-viewer.fxml
+++ b/log-viewer/src/main/resources/qupath/ui/logviewer/log-viewer.fxml
@@ -26,13 +26,13 @@
       <BorderPane prefHeight="200.0" prefWidth="200.0" BorderPane.alignment="CENTER">
          <center>
              <SplitPane dividerPositions="0.659919028340081" orientation="VERTICAL" prefHeight="200.0" prefWidth="160.0" BorderPane.alignment="CENTER">
-                 <TableView fx:id="tableViewLog" prefHeight="200.0" prefWidth="200.0" tableMenuButtonVisible="true">
+                 <TableView fx:id="tableViewLog" prefHeight="200.0" prefWidth="200.0" styleClass="log-table" tableMenuButtonVisible="true">
                      <columns>
-                         <TableColumn fx:id="colRow" editable="false" maxWidth="50.0" prefWidth="30.0" sortable="false" text="#" />
-                         <TableColumn fx:id="colLevel" editable="false" maxWidth="60.0" prefWidth="60.0" sortable="false" text="%Table.level" />
+                         <TableColumn fx:id="colRow" editable="false" maxWidth="50.0" prefWidth="30.0" sortable="false" text="#" visible="false" />
+                         <TableColumn fx:id="colLevel" editable="false" maxWidth="60.0" prefWidth="25.0" sortable="false" />
+                         <TableColumn fx:id="colTimestamp" editable="false" maxWidth="120.0" prefWidth="85.5" sortable="false" text="%Table.time" />
                          <TableColumn fx:id="colThread" editable="false" maxWidth="1.7976931348623157E308" prefWidth="90.0" sortable="false" text="%Table.thread" />
                          <TableColumn fx:id="colLogger" editable="false" maxWidth="1.7976931348623157E308" prefWidth="90.0" sortable="false" text="%Table.logger" />
-                         <TableColumn fx:id="colTimestamp" editable="false" maxWidth="120.0" prefWidth="90.0" sortable="false" text="%Table.time" />
                          <TableColumn fx:id="colMessage" editable="false" maxWidth="1.7976931348623157E308" prefWidth="400.0" sortable="false" styleClass="col-message" text="%Table.message" />
                      </columns>
                     <contextMenu>
@@ -42,6 +42,9 @@
                             </items>
                         </ContextMenu>
                     </contextMenu>
+                  <columnResizePolicy>
+                     <TableView fx:constant="CONSTRAINED_RESIZE_POLICY" />
+                  </columnResizePolicy>
                  </TableView>
                  <TextArea fx:id="textAreaLog" editable="false" prefHeight="200.0" prefWidth="200.0" />
              </SplitPane>


### PR DESCRIPTION
### Proposed changes

* Decrease font size within the log table
* Rearrange and hide some columns by default
* Remove 'Level' column header (because it takes extra space)

### Before

<img width="800" alt="Before" src="https://github.com/qupath/log-viewer/assets/4690904/bce83ef4-b83d-45be-a29d-7003022239c2">

### After

<img width="800" alt="After" src="https://github.com/qupath/log-viewer/assets/4690904/fb6095ab-e65c-4b7e-a552-863dc012c267">

