### PR TITLE
Minor fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,1 @@
-tasks.named('wrapper') {
-    distributionType = Wrapper.DistributionType.ALL
-}
-
 version = "0.1.0-SNAPSHOT"

--- a/buildSrc/src/main/groovy/logviewer.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/logviewer.java-conventions.gradle
@@ -7,4 +7,5 @@ java {
     withJavadocJar()
 }
 
+group = 'io.github.qupath'
 version = rootProject.version

--- a/buildSrc/src/main/groovy/logviewer.publishing-conventions.gradle
+++ b/buildSrc/src/main/groovy/logviewer.publishing-conventions.gradle
@@ -19,7 +19,6 @@ publishing {
 
     publications {
         mavenJava(MavenPublication) {
-            groupId = 'io.github.qupath'
             from components.java
 
             pom {


### PR DESCRIPTION
* Fix issue with scroll-to-bottom behavior that meant it could fail for high numbers of log messages (e.g. at trace level)
* Minimize processing when the log viewer isn't visible, to try to improve performance
* Specify group in `build.gradle`, so that `includeBuild` can be used to test logger within other projects