### PR TITLE
Reduce JavaFX version requirement 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,1 +1,1 @@
-version = "0.1.1-SNAPSHOT"
+version = "0.1.1"

--- a/build.gradle
+++ b/build.gradle
@@ -1,1 +1,1 @@
-version = "0.1.0"
+version = "0.1.1-SNAPSHOT"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ slf4j = "2.0.7"
 logback = "1.3.5"
 reload4j = "1.2.25"
 richtextfx = "0.11.0"
-javafx = "20.0.1"
+javafx = "20"
 javafxPlugin = "0.1.0"
 jlink = "2.12.0"
 


### PR DESCRIPTION
20 is the minimum required, so we shouldn't declare a higher version to avoid enforcing that on others (and 20.0.1 has problem problematic with its `WebView`...).

Other dependency requirements might also be reduced in the future.