### PR TITLE
Minor optimization, macOS workaround

### DIFF
--- a/logviewer-ui-main/src/main/java/qupath/ui/logviewer/ui/main/LogViewer.java
+++ b/logviewer-ui-main/src/main/java/qupath/ui/logviewer/ui/main/LogViewer.java
@@ -579,7 +579,12 @@ public class LogViewer extends BorderPane {
             RadioMenuItem item = new RadioMenuItem(threadName);
             item.setOnAction(this::onThreadItemSelected);
             item.setToggleGroup(threadFilterGroup);
-            threadFilterMenu.getItems().add(item);
+
+            // Create a new list instead of simply adding the item is a workaround for
+            // https://github.com/qupath/log-viewer/issues/70
+            var newItems = new ArrayList<>(threadFilterMenu.getItems());
+            newItems.add(item);
+            threadFilterMenu.getItems().setAll(newItems);
         });
     }
 

--- a/logviewer-ui-main/src/main/java/qupath/ui/logviewer/ui/main/LogViewerModel.java
+++ b/logviewer-ui-main/src/main/java/qupath/ui/logviewer/ui/main/LogViewerModel.java
@@ -284,7 +284,13 @@ class LogViewerModel implements LoggerListener {
         allLogs.addListener((ListChangeListener<? super LogMessage>) change -> {
             while (change.next()) {
                 if (change.wasAdded()) {
-                    allThreads.addAll(change.getAddedSubList().stream().map(LogMessage::threadName).toList());
+                    // Use loop rather than collecting names and using 'addAll' to reduce overhead.
+                    // We expect this to be called often, the name is usually in the set already,
+                    // and observable sets don't seem to support batch updates anyway
+                    // ('addAll' seems to just call 'add' in a loop)
+                    for (var item : change.getAddedSubList()) {
+                        allThreads.add(item.threadName());
+                    }
                 }
             }
         });


### PR DESCRIPTION
* Provides a workaround to https://github.com/qupath/log-viewer/issues/70
* Slightly reduces the overhead on each logging call when using the JavaFX UI, eliminating the creation of several new objects.